### PR TITLE
Split loop for forward and reverse calculation

### DIFF
--- a/src/stellar_output.h
+++ b/src/stellar_output.h
@@ -415,19 +415,13 @@ void _appendDisabledQueryToFastaFile(CharString const & id, TQuery const & query
     disabledQueriesFile << query << "\n\n";
 }
 
-template <typename TInfix, typename TQueryId, typename TIds, typename TQueries>
-void _writeDisabledQueriesToFastaFile(StringSet<QueryMatches<StellarMatch<TInfix const, TQueryId> > > const & matches, TIds const & ids, TQueries const & queries, std::ofstream & disabledQueriesFile)
+template <typename TIds, typename TQueries>
+void _writeDisabledQueriesToFastaFile(std::vector<size_t> const & disabledQueryIDs, TIds const & ids, TQueries const & queries, std::ofstream & disabledQueriesFile)
 {
     assert(disabledQueriesFile.is_open());
 
-    for (size_t i = 0u; i < length(matches); i++) {
-        QueryMatches<StellarMatch<TInfix const, TQueryId>> const & queryMatches = value(matches, i);
-
-        if (!queryMatches.disabled)
-            continue;
-
-        _appendDisabledQueryToFastaFile(ids[i], queries[i], disabledQueriesFile);
-    }
+    for (size_t queryID : disabledQueryIDs)
+        _appendDisabledQueryToFastaFile(ids[queryID], queries[queryID], disabledQueriesFile);
 }
 
 template <typename TInfix, typename TQueryId>

--- a/src/stellar_types.h
+++ b/src/stellar_types.h
@@ -141,6 +141,14 @@ struct StellarOutputStatistics
     size_t totalLength{0u};
     size_t numMatches{0u};
     size_t numDisabled{0u};
+
+    void mergeIn(StellarOutputStatistics const & statistics)
+    {
+        maxLength = std::max(maxLength, statistics.maxLength);
+        totalLength = totalLength + statistics.totalLength;
+        numMatches = numMatches + statistics.numMatches;
+        numDisabled = numDisabled + statistics.numDisabled;
+    }
 };
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/test/cli/gold_standard/dna5_both/5e-2_minLen20_100kbsplit.gff.stdout
+++ b/test/cli/gold_standard/dna5_both/5e-2_minLen20_100kbsplit.gff.stdout
@@ -37,78 +37,78 @@ Aligning all query sequences to database sequence...
     # SWIFT hits      : 1496
     Longest hit       : 192
     Avg hit length    : 18
-  seq1::0:100000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200, complement
-    # SWIFT hits      : 1390
-    Longest hit       : 37
-    Avg hit length    : 14
   seq1::100000:200000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200
     # SWIFT hits      : 1482
     Longest hit       : 196
     Avg hit length    : 17
-  seq1::100000:200000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200, complement
-    # SWIFT hits      : 1390
-    Longest hit       : 32
-    Avg hit length    : 14
   seq1::200000:300000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200
     # SWIFT hits      : 1480
     Longest hit       : 202
     Avg hit length    : 17
-  seq1::200000:300000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200, complement
-    # SWIFT hits      : 1448
-    Longest hit       : 39
-    Avg hit length    : 14
   seq1::300000:400000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200
     # SWIFT hits      : 1380
     Longest hit       : 197
     Avg hit length    : 17
-  seq1::300000:400000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200, complement
-    # SWIFT hits      : 1338
-    Longest hit       : 36
-    Avg hit length    : 14
   seq1::400000:500000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200
     # SWIFT hits      : 1497
     Longest hit       : 195
     Avg hit length    : 17
-  seq1::400000:500000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200, complement
-    # SWIFT hits      : 1410
-    Longest hit       : 34
-    Avg hit length    : 14
   seq1::500000:600000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200
     # SWIFT hits      : 1500
     Longest hit       : 194
     Avg hit length    : 18
-  seq1::500000:600000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200, complement
-    # SWIFT hits      : 1390
-    Longest hit       : 35
-    Avg hit length    : 14
   seq1::600000:700000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200
     # SWIFT hits      : 1485
     Longest hit       : 198
     Avg hit length    : 18
-  seq1::600000:700000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200, complement
-    # SWIFT hits      : 1414
-    Longest hit       : 39
-    Avg hit length    : 14
   seq1::700000:800000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200
     # SWIFT hits      : 1491
     Longest hit       : 198
     Avg hit length    : 18
-  seq1::700000:800000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200, complement
-    # SWIFT hits      : 1387
-    Longest hit       : 31
-    Avg hit length    : 14
   seq1::800000:900000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200
     # SWIFT hits      : 1475
     Longest hit       : 200
     Avg hit length    : 18
-  seq1::800000:900000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200, complement
-    # SWIFT hits      : 1449
-    Longest hit       : 36
-    Avg hit length    : 14
   seq1::900000:1000000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200
     # SWIFT hits      : 1433
     Longest hit       : 194
     Avg hit length    : 19
+  seq1::0:100000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200, complement
+    # SWIFT hits      : 1390
+    Longest hit       : 37
+    Avg hit length    : 14
+  seq1::100000:200000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200, complement
+    # SWIFT hits      : 1390
+    Longest hit       : 32
+    Avg hit length    : 14
+  seq1::200000:300000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200, complement
+    # SWIFT hits      : 1448
+    Longest hit       : 39
+    Avg hit length    : 14
+  seq1::300000:400000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200, complement
+    # SWIFT hits      : 1338
+    Longest hit       : 36
+    Avg hit length    : 14
+  seq1::400000:500000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200, complement
+    # SWIFT hits      : 1410
+    Longest hit       : 34
+    Avg hit length    : 14
+  seq1::500000:600000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200, complement
+    # SWIFT hits      : 1390
+    Longest hit       : 35
+    Avg hit length    : 14
+  seq1::600000:700000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200, complement
+    # SWIFT hits      : 1414
+    Longest hit       : 39
+    Avg hit length    : 14
+  seq1::700000:800000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200, complement
+    # SWIFT hits      : 1387
+    Longest hit       : 31
+    Avg hit length    : 14
+  seq1::800000:900000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200, complement
+    # SWIFT hits      : 1449
+    Longest hit       : 36
+    Avg hit length    : 14
   seq1::900000:1000000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200, complement
     # SWIFT hits      : 1376
     Longest hit       : 37

--- a/test/cli/gold_standard/dna5_both/5e-2_minLen20_100kbsplit.txt.stdout
+++ b/test/cli/gold_standard/dna5_both/5e-2_minLen20_100kbsplit.txt.stdout
@@ -37,78 +37,78 @@ Aligning all query sequences to database sequence...
     # SWIFT hits      : 1496
     Longest hit       : 192
     Avg hit length    : 18
-  seq1::0:100000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200, complement
-    # SWIFT hits      : 1390
-    Longest hit       : 37
-    Avg hit length    : 14
   seq1::100000:200000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200
     # SWIFT hits      : 1482
     Longest hit       : 196
     Avg hit length    : 17
-  seq1::100000:200000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200, complement
-    # SWIFT hits      : 1390
-    Longest hit       : 32
-    Avg hit length    : 14
   seq1::200000:300000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200
     # SWIFT hits      : 1480
     Longest hit       : 202
     Avg hit length    : 17
-  seq1::200000:300000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200, complement
-    # SWIFT hits      : 1448
-    Longest hit       : 39
-    Avg hit length    : 14
   seq1::300000:400000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200
     # SWIFT hits      : 1380
     Longest hit       : 197
     Avg hit length    : 17
-  seq1::300000:400000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200, complement
-    # SWIFT hits      : 1338
-    Longest hit       : 36
-    Avg hit length    : 14
   seq1::400000:500000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200
     # SWIFT hits      : 1497
     Longest hit       : 195
     Avg hit length    : 17
-  seq1::400000:500000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200, complement
-    # SWIFT hits      : 1410
-    Longest hit       : 34
-    Avg hit length    : 14
   seq1::500000:600000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200
     # SWIFT hits      : 1500
     Longest hit       : 194
     Avg hit length    : 18
-  seq1::500000:600000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200, complement
-    # SWIFT hits      : 1390
-    Longest hit       : 35
-    Avg hit length    : 14
   seq1::600000:700000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200
     # SWIFT hits      : 1485
     Longest hit       : 198
     Avg hit length    : 18
-  seq1::600000:700000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200, complement
-    # SWIFT hits      : 1414
-    Longest hit       : 39
-    Avg hit length    : 14
   seq1::700000:800000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200
     # SWIFT hits      : 1491
     Longest hit       : 198
     Avg hit length    : 18
-  seq1::700000:800000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200, complement
-    # SWIFT hits      : 1387
-    Longest hit       : 31
-    Avg hit length    : 14
   seq1::800000:900000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200
     # SWIFT hits      : 1475
     Longest hit       : 200
     Avg hit length    : 18
-  seq1::800000:900000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200, complement
-    # SWIFT hits      : 1449
-    Longest hit       : 36
-    Avg hit length    : 14
   seq1::900000:1000000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200
     # SWIFT hits      : 1433
     Longest hit       : 194
     Avg hit length    : 19
+  seq1::0:100000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200, complement
+    # SWIFT hits      : 1390
+    Longest hit       : 37
+    Avg hit length    : 14
+  seq1::100000:200000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200, complement
+    # SWIFT hits      : 1390
+    Longest hit       : 32
+    Avg hit length    : 14
+  seq1::200000:300000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200, complement
+    # SWIFT hits      : 1448
+    Longest hit       : 39
+    Avg hit length    : 14
+  seq1::300000:400000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200, complement
+    # SWIFT hits      : 1338
+    Longest hit       : 36
+    Avg hit length    : 14
+  seq1::400000:500000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200, complement
+    # SWIFT hits      : 1410
+    Longest hit       : 34
+    Avg hit length    : 14
+  seq1::500000:600000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200, complement
+    # SWIFT hits      : 1390
+    Longest hit       : 35
+    Avg hit length    : 14
+  seq1::600000:700000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200, complement
+    # SWIFT hits      : 1414
+    Longest hit       : 39
+    Avg hit length    : 14
+  seq1::700000:800000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200, complement
+    # SWIFT hits      : 1387
+    Longest hit       : 31
+    Avg hit length    : 14
+  seq1::800000:900000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200, complement
+    # SWIFT hits      : 1449
+    Longest hit       : 36
+    Avg hit length    : 14
   seq1::900000:1000000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200, complement
     # SWIFT hits      : 1376
     Longest hit       : 37

--- a/test/cli/gold_standard/dna_both/5e-2_minLen20_100kbsplit.gff.stdout
+++ b/test/cli/gold_standard/dna_both/5e-2_minLen20_100kbsplit.gff.stdout
@@ -34,78 +34,78 @@ Aligning all query sequences to database sequence...
     # SWIFT hits      : 1496
     Longest hit       : 192
     Avg hit length    : 18
-  seq1::0:100000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200, complement
-    # SWIFT hits      : 1390
-    Longest hit       : 37
-    Avg hit length    : 14
   seq1::100000:200000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200
     # SWIFT hits      : 1482
     Longest hit       : 196
     Avg hit length    : 17
-  seq1::100000:200000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200, complement
-    # SWIFT hits      : 1390
-    Longest hit       : 32
-    Avg hit length    : 14
   seq1::200000:300000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200
     # SWIFT hits      : 1480
     Longest hit       : 202
     Avg hit length    : 17
-  seq1::200000:300000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200, complement
-    # SWIFT hits      : 1448
-    Longest hit       : 39
-    Avg hit length    : 14
   seq1::300000:400000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200
     # SWIFT hits      : 1380
     Longest hit       : 197
     Avg hit length    : 17
-  seq1::300000:400000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200, complement
-    # SWIFT hits      : 1338
-    Longest hit       : 36
-    Avg hit length    : 14
   seq1::400000:500000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200
     # SWIFT hits      : 1497
     Longest hit       : 195
     Avg hit length    : 17
-  seq1::400000:500000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200, complement
-    # SWIFT hits      : 1410
-    Longest hit       : 34
-    Avg hit length    : 14
   seq1::500000:600000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200
     # SWIFT hits      : 1500
     Longest hit       : 194
     Avg hit length    : 18
-  seq1::500000:600000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200, complement
-    # SWIFT hits      : 1390
-    Longest hit       : 35
-    Avg hit length    : 14
   seq1::600000:700000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200
     # SWIFT hits      : 1485
     Longest hit       : 198
     Avg hit length    : 18
-  seq1::600000:700000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200, complement
-    # SWIFT hits      : 1414
-    Longest hit       : 39
-    Avg hit length    : 14
   seq1::700000:800000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200
     # SWIFT hits      : 1491
     Longest hit       : 198
     Avg hit length    : 18
-  seq1::700000:800000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200, complement
-    # SWIFT hits      : 1387
-    Longest hit       : 31
-    Avg hit length    : 14
   seq1::800000:900000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200
     # SWIFT hits      : 1475
     Longest hit       : 200
     Avg hit length    : 18
-  seq1::800000:900000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200, complement
-    # SWIFT hits      : 1449
-    Longest hit       : 36
-    Avg hit length    : 14
   seq1::900000:1000000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200
     # SWIFT hits      : 1433
     Longest hit       : 194
     Avg hit length    : 19
+  seq1::0:100000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200, complement
+    # SWIFT hits      : 1390
+    Longest hit       : 37
+    Avg hit length    : 14
+  seq1::100000:200000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200, complement
+    # SWIFT hits      : 1390
+    Longest hit       : 32
+    Avg hit length    : 14
+  seq1::200000:300000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200, complement
+    # SWIFT hits      : 1448
+    Longest hit       : 39
+    Avg hit length    : 14
+  seq1::300000:400000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200, complement
+    # SWIFT hits      : 1338
+    Longest hit       : 36
+    Avg hit length    : 14
+  seq1::400000:500000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200, complement
+    # SWIFT hits      : 1410
+    Longest hit       : 34
+    Avg hit length    : 14
+  seq1::500000:600000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200, complement
+    # SWIFT hits      : 1390
+    Longest hit       : 35
+    Avg hit length    : 14
+  seq1::600000:700000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200, complement
+    # SWIFT hits      : 1414
+    Longest hit       : 39
+    Avg hit length    : 14
+  seq1::700000:800000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200, complement
+    # SWIFT hits      : 1387
+    Longest hit       : 31
+    Avg hit length    : 14
+  seq1::800000:900000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200, complement
+    # SWIFT hits      : 1449
+    Longest hit       : 36
+    Avg hit length    : 14
   seq1::900000:1000000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200, complement
     # SWIFT hits      : 1376
     Longest hit       : 37

--- a/test/cli/gold_standard/dna_both/5e-2_minLen20_100kbsplit.txt.stdout
+++ b/test/cli/gold_standard/dna_both/5e-2_minLen20_100kbsplit.txt.stdout
@@ -34,78 +34,78 @@ Aligning all query sequences to database sequence...
     # SWIFT hits      : 1496
     Longest hit       : 192
     Avg hit length    : 18
-  seq1::0:100000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200, complement
-    # SWIFT hits      : 1390
-    Longest hit       : 37
-    Avg hit length    : 14
   seq1::100000:200000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200
     # SWIFT hits      : 1482
     Longest hit       : 196
     Avg hit length    : 17
-  seq1::100000:200000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200, complement
-    # SWIFT hits      : 1390
-    Longest hit       : 32
-    Avg hit length    : 14
   seq1::200000:300000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200
     # SWIFT hits      : 1480
     Longest hit       : 202
     Avg hit length    : 17
-  seq1::200000:300000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200, complement
-    # SWIFT hits      : 1448
-    Longest hit       : 39
-    Avg hit length    : 14
   seq1::300000:400000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200
     # SWIFT hits      : 1380
     Longest hit       : 197
     Avg hit length    : 17
-  seq1::300000:400000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200, complement
-    # SWIFT hits      : 1338
-    Longest hit       : 36
-    Avg hit length    : 14
   seq1::400000:500000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200
     # SWIFT hits      : 1497
     Longest hit       : 195
     Avg hit length    : 17
-  seq1::400000:500000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200, complement
-    # SWIFT hits      : 1410
-    Longest hit       : 34
-    Avg hit length    : 14
   seq1::500000:600000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200
     # SWIFT hits      : 1500
     Longest hit       : 194
     Avg hit length    : 18
-  seq1::500000:600000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200, complement
-    # SWIFT hits      : 1390
-    Longest hit       : 35
-    Avg hit length    : 14
   seq1::600000:700000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200
     # SWIFT hits      : 1485
     Longest hit       : 198
     Avg hit length    : 18
-  seq1::600000:700000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200, complement
-    # SWIFT hits      : 1414
-    Longest hit       : 39
-    Avg hit length    : 14
   seq1::700000:800000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200
     # SWIFT hits      : 1491
     Longest hit       : 198
     Avg hit length    : 18
-  seq1::700000:800000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200, complement
-    # SWIFT hits      : 1387
-    Longest hit       : 31
-    Avg hit length    : 14
   seq1::800000:900000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200
     # SWIFT hits      : 1475
     Longest hit       : 200
     Avg hit length    : 18
-  seq1::800000:900000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200, complement
-    # SWIFT hits      : 1449
-    Longest hit       : 36
-    Avg hit length    : 14
   seq1::900000:1000000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200
     # SWIFT hits      : 1433
     Longest hit       : 194
     Avg hit length    : 19
+  seq1::0:100000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200, complement
+    # SWIFT hits      : 1390
+    Longest hit       : 37
+    Avg hit length    : 14
+  seq1::100000:200000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200, complement
+    # SWIFT hits      : 1390
+    Longest hit       : 32
+    Avg hit length    : 14
+  seq1::200000:300000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200, complement
+    # SWIFT hits      : 1448
+    Longest hit       : 39
+    Avg hit length    : 14
+  seq1::300000:400000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200, complement
+    # SWIFT hits      : 1338
+    Longest hit       : 36
+    Avg hit length    : 14
+  seq1::400000:500000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200, complement
+    # SWIFT hits      : 1410
+    Longest hit       : 34
+    Avg hit length    : 14
+  seq1::500000:600000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200, complement
+    # SWIFT hits      : 1390
+    Longest hit       : 35
+    Avg hit length    : 14
+  seq1::600000:700000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200, complement
+    # SWIFT hits      : 1414
+    Longest hit       : 39
+    Avg hit length    : 14
+  seq1::700000:800000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200, complement
+    # SWIFT hits      : 1387
+    Longest hit       : 31
+    Avg hit length    : 14
+  seq1::800000:900000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200, complement
+    # SWIFT hits      : 1449
+    Longest hit       : 36
+    Avg hit length    : 14
   seq1::900000:1000000 length=1000000 numMatches=500 errorRate=0.05 matchMinLength=50 matchMaxLength=200, complement
     # SWIFT hits      : 1376
     Longest hit       : 37


### PR DESCRIPTION
This changes the order of execution (first all forward strands, after
that all reverse strands), but the output (gff and txt) stays
the same.