### PR TITLE
Major: pass onAlignmentResult callback instead of explicit querymatches.

### DIFF
--- a/include/stellar/verification/all_local.hpp
+++ b/include/stellar/verification/all_local.hpp
@@ -9,8 +9,8 @@ namespace stellar
 ///////////////////////////////////////////////////////////////////////////////
 // Conducts banded local alignment on swift hit (= computes eps-cores),
 //  splits eps-cores at X-drops, and calls _extendAndExtract for extension of eps-cores
-template<typename TSequence, typename TEpsilon, typename TSize, typename TDelta, typename TDrop,
-         typename TSize1, typename TId, typename TSource>
+template<typename TSequence, typename TEpsilon, typename TSize, typename TDrop, typename TDelta,
+         typename TOnAlignmentResultFn>
 void
 verifySwiftHit(Segment<Segment<TSequence const, InfixSegment>, InfixSegment> const & infH,
                Segment<Segment<TSequence const, InfixSegment>, InfixSegment> const & infV,
@@ -18,28 +18,11 @@ verifySwiftHit(Segment<Segment<TSequence const, InfixSegment>, InfixSegment> con
                TSize const minLength,
                TDrop const xDrop,
                TDelta const delta,
-               TSize1 const disableThresh,
-               TSize1 & compactThresh,
-               TSize1 const numMatches,
-               TId const & databaseId,
-               bool const dbStrand,
-               QueryMatches<StellarMatch<TSource const, TId> > & matches,
+               TOnAlignmentResultFn && onAlignmentResult,
                AllLocal) {
-    allOrBestLocal(
-        infH,
-        infV,
-        eps,
-        minLength,
-        xDrop,
-        delta,
-        disableThresh,
-        compactThresh,
-        numMatches,
-        databaseId,
-        dbStrand,
-        matches,
-        std::false_type{} // all local matches
-    );
+
+    // false == all local matches
+    allOrBestLocal(infH, infV, eps, minLength, xDrop, delta, onAlignmentResult, std::false_type{});
 }
 
 } // namespace stellar

--- a/include/stellar/verification/banded_global.hpp
+++ b/include/stellar/verification/banded_global.hpp
@@ -8,8 +8,8 @@ namespace stellar
 
 ///////////////////////////////////////////////////////////////////////////////
 // Conducts banded alignment on swift hit and extracts longest contained eps-match.
-template<typename TSequence, typename TEpsilon, typename TSize, typename TDelta,
-         typename TDrop, typename TSize1, typename TSource, typename TId>
+template<typename TSequence, typename TEpsilon, typename TSize, typename TDrop, typename TDelta,
+         typename TOnAlignmentResultFn>
 void
 verifySwiftHit(Segment<Segment<TSequence const, InfixSegment>, InfixSegment> const & infH,
                Segment<Segment<TSequence const, InfixSegment>, InfixSegment> const & infV,
@@ -17,16 +17,11 @@ verifySwiftHit(Segment<Segment<TSequence const, InfixSegment>, InfixSegment> con
                TSize const minLength,
                TDrop /*xDrop*/,
                TDelta const delta,
-               TSize1 const disableThresh,
-               TSize1 & compactThresh,
-               TSize1 const numMatches,
-               TId const & databaseId,
-               bool const dbStrand,
-               QueryMatches<StellarMatch<TSource const, TId> > & matches,
+               TOnAlignmentResultFn && onAlignmentResult,
                BandedGlobal) {
     using TInfix = Segment<TSequence const, InfixSegment>;
     typedef Segment<TInfix, InfixSegment> TSegment;
-    typedef typename StellarMatch<TSource const, TId>::TAlign TAlign;
+    typedef typename StellarMatch<TSequence const, CharString>::TAlign TAlign;
 
     // define a scoring scheme
     typedef int TScore;
@@ -70,8 +65,7 @@ verifySwiftHit(Segment<Segment<TSequence const, InfixSegment>, InfixSegment> con
         return;
 
     // insert eps-match in matches string
-    StellarMatch<TSource const, TId> m(align, databaseId, dbStrand);
-    _insertMatch(matches, m, minLength, disableThresh, compactThresh, numMatches);
+    onAlignmentResult(align);
 }
 
 } // namespace stellar

--- a/include/stellar/verification/banded_global_extend.hpp
+++ b/include/stellar/verification/banded_global_extend.hpp
@@ -9,8 +9,8 @@ namespace stellar
 
 ///////////////////////////////////////////////////////////////////////////////
 // Conducts banded alignment on swift hit, extends alignment, and extracts longest contained eps-match.
-template<typename TSequence, typename TEpsilon, typename TSize, typename TDelta,
-         typename TDrop, typename TSize1, typename TSource, typename TId>
+template<typename TSequence, typename TEpsilon, typename TSize, typename TDrop, typename TDelta,
+         typename TOnAlignmentResultFn>
 void
 verifySwiftHit(Segment<Segment<TSequence const, InfixSegment>, InfixSegment> const & infH,
                Segment<Segment<TSequence const, InfixSegment>, InfixSegment> const & infV,
@@ -18,16 +18,11 @@ verifySwiftHit(Segment<Segment<TSequence const, InfixSegment>, InfixSegment> con
                TSize const minLength,
                TDrop const xDrop,
                TDelta const delta,
-               TSize1 const disableThresh,
-               TSize1 & compactThresh,
-               TSize1 const numMatches,
-               TId const & databaseId,
-               bool const dbStrand,
-               QueryMatches<StellarMatch<TSource const, TId> > & matches,
+               TOnAlignmentResultFn && onAlignmentResult,
                BandedGlobalExtend) {
     using TInfix = Segment<TSequence const, InfixSegment>;
     typedef Segment<TInfix, InfixSegment> TSegment;
-    typedef typename StellarMatch<TSource const, TId>::TAlign TAlign;
+    typedef typename StellarMatch<TSequence const, CharString>::TAlign TAlign;
 
     // define a scoring scheme
     typedef int TScore;
@@ -61,8 +56,7 @@ verifySwiftHit(Segment<Segment<TSequence const, InfixSegment>, InfixSegment> con
         return;
 
     // insert eps-match in matches string
-    StellarMatch<TSource const, TId> m(align, databaseId, dbStrand);
-    _insertMatch(matches, m, minLength, disableThresh, compactThresh, numMatches);
+    onAlignmentResult(align);
 }
 
 } // namespace stellar

--- a/include/stellar/verification/best_local.hpp
+++ b/include/stellar/verification/best_local.hpp
@@ -9,8 +9,8 @@ namespace stellar
 ///////////////////////////////////////////////////////////////////////////////
 // Conducts banded local alignment on swift hit (= computes eps-cores),
 //  splits eps-cores at X-drops, and calls _extendAndExtract for extension of eps-cores
-template<typename TSequence, typename TEpsilon, typename TSize, typename TDelta, typename TDrop,
-         typename TSize1, typename TId, typename TSource>
+template<typename TSequence, typename TEpsilon, typename TSize, typename TDrop, typename TDelta,
+         typename TOnAlignmentResultFn>
 void
 verifySwiftHit(Segment<Segment<TSequence const, InfixSegment>, InfixSegment> const & infH,
                Segment<Segment<TSequence const, InfixSegment>, InfixSegment> const & infV,
@@ -18,28 +18,11 @@ verifySwiftHit(Segment<Segment<TSequence const, InfixSegment>, InfixSegment> con
                TSize const minLength,
                TDrop const xDrop,
                TDelta const delta,
-               TSize1 const disableThresh,
-               TSize1 & compactThresh,
-               TSize1 const numMatches,
-               TId const & databaseId,
-               bool const dbStrand,
-               QueryMatches<StellarMatch<TSource const, TId> > & matches,
+               TOnAlignmentResultFn && onAlignmentResult,
                BestLocal) {
-    allOrBestLocal(
-        infH,
-        infV,
-        eps,
-        minLength,
-        xDrop,
-        delta,
-        disableThresh,
-        compactThresh,
-        numMatches,
-        databaseId,
-        dbStrand,
-        matches,
-        std::true_type{} // true == best local match
-    );
+
+    // true == best local match
+    allOrBestLocal(infH, infV, eps, minLength, xDrop, delta, onAlignmentResult, std::true_type{});
 }
 
 } // namespace stellar

--- a/include/stellar/verification/swift_hit_verifier.hpp
+++ b/include/stellar/verification/swift_hit_verifier.hpp
@@ -10,27 +10,19 @@ struct SwiftHitVerifier
 {
     using TSize = int;
     using TDrop = double;
-    using TSize1 = unsigned;
-    using TId = CharString;
 
     double const epsilon;
     TSize const minLength;
     TDrop const xDrop;
-    TSize1 const disableThresh;
-    TSize1 & compactThresh; // will be updated in _insertMatch
-    TSize1 const numMatches;
-    TId const & databaseID;
-    bool const databaseStrand;
 
-    template <typename TSequence, typename TDelta, typename TSource, typename TId>
+    template <typename TSequence, typename TDelta, typename TOnAlignmentResultFn>
     void verify(Segment<Segment<TSequence const, InfixSegment>, InfixSegment> const & finderSegment,
                 Segment<Segment<TSequence const, InfixSegment>, InfixSegment> const & patternSegment,
                 TDelta const delta,
-                QueryMatches<StellarMatch<TSource const, TId> > & queryMatches)
+                TOnAlignmentResultFn && onAlignmentResult)
     {
         verifySwiftHit(finderSegment, patternSegment, epsilon, minLength, xDrop,
-                       delta, disableThresh, compactThresh,
-                       numMatches, databaseID, databaseStrand, queryMatches, TVerifierTag{});
+                       delta, onAlignmentResult, TVerifierTag{});
     }
 };
 


### PR DESCRIPTION
This decouples the verification step from the result collection.
AND massively reduces passed arguments